### PR TITLE
Private image support

### DIFF
--- a/modules/instance/main.tf
+++ b/modules/instance/main.tf
@@ -42,18 +42,19 @@ module "iap_firewall" {
   Render start up and cloud config scripts from templates
  ***********************************************/
 module "template_files" {
-  source                    = "../template_files"
-  cloud_config              = local.cloud_config
-  append_to_startup_script  = var.append_to_startup_script
-  datalab_disk_name         = local.datalab_disk_name
-  datalab_enable_swap       = var.datalab_enable_swap
-  datalab_docker_image      = local.datalab_docker_image
-  datalab_enable_backup     = var.datalab_enable_backup
-  datalab_console_log_level = var.datalab_console_log_level
-  datalab_user_email        = var.datalab_user_email
-  datalab_idle_timeout      = var.datalab_idle_timeout
-  fluentd_docker_image      = var.fluentd_docker_image
-  gpu_count                 = var.gpu_count
+  source                        = "../template_files"
+  cloud_config                  = local.cloud_config
+  append_to_startup_script      = var.append_to_startup_script
+  datalab_disk_name             = local.datalab_disk_name
+  datalab_enable_swap           = var.datalab_enable_swap
+  datalab_docker_image          = local.datalab_docker_image
+  datalab_enable_backup         = var.datalab_enable_backup
+  datalab_console_log_level     = var.datalab_console_log_level
+  datalab_user_email            = var.datalab_user_email
+  datalab_idle_timeout          = var.datalab_idle_timeout
+  fluentd_docker_image          = var.fluentd_docker_image
+  gpu_count                     = var.gpu_count
+  private_datalab_registry_info = var.private_datalab_registry_info
 }
 
 /***********************************************

--- a/modules/instance/variables.tf
+++ b/modules/instance/variables.tf
@@ -143,3 +143,13 @@ variable "enable_secure_boot" {
   description = "Verify the digital signature of all boot components, and halt the boot process if signature verification fails"
   default     = false
 }
+
+variable "private_datalab_registry_info" {
+  type = object({
+    secret_project_id   = string
+    user_secret_id      = string
+    password_secret_id  = string
+    docker_registry_url = string
+  })
+  default = null
+}

--- a/modules/template_files/main.tf
+++ b/modules/template_files/main.tf
@@ -55,8 +55,8 @@ data "google_secret_manager_secret_version" "docker_registry_password" {
 
 locals {
   docker_registry = var.private_datalab_registry_info == null ? "" : var.private_datalab_registry_info.docker_registry_url
-  docker_user     = var.private_datalab_registry_info == null ? "" : data.google_secret_manager_secret_version.docker_registry_user.secret_data
-  docker_password = var.private_datalab_registry_info == null ? "" : data.google_secret_manager_secret_version.docker_registry_password.secret_data
+  docker_user     = var.private_datalab_registry_info == null ? "" : data.google_secret_manager_secret_version.docker_registry_user[0].secret_data
+  docker_password = var.private_datalab_registry_info == null ? "" : data.google_secret_manager_secret_version.docker_registry_password[0].secret_data
 }
 
 /***********************************************

--- a/modules/template_files/templates/startup_script.tpl
+++ b/modules/template_files/templates/startup_script.tpl
@@ -38,7 +38,7 @@ download_docker_image() {
   # directory is used later on by the datalab.service.
   export OLD_HOME=$HOME
   export HOME=/home/datalab
-  if [[ -z "$DOCKER_REGISTRY" ]]; then
+  if [[ ! -z "$DOCKER_REGISTRY" ]]; then
     echo "Logging into $${DOCKER_REGISTRY}"
     login_docker_registry
   fi

--- a/modules/template_files/templates/startup_script.tpl
+++ b/modules/template_files/templates/startup_script.tpl
@@ -30,7 +30,7 @@ chown -R logger /home/logger
 PERSISTENT_DISK_DEV="/dev/disk/by-id/google-${disk_name}"
 MOUNT_DIR="/mnt/disks/datalab-pd"
 MOUNT_CMD="mount -o discard,defaults $${PERSISTENT_DISK_DEV} $${MOUNT_DIR}"
-DOCKER_REGISTRY=${docker_registry}
+DOCKER_REGISTRY="${docker_registry}"
 
 download_docker_image() {
   # Since /root/.docker is not writable on the default image,
@@ -38,7 +38,7 @@ download_docker_image() {
   # directory is used later on by the datalab.service.
   export OLD_HOME=$HOME
   export HOME=/home/datalab
-  if [ -z "$DOCKER_REGISTRY" ]; then
+  if [[ -z "$DOCKER_REGISTRY" ]]; then
     echo "Logging into $${DOCKER_REGISTRY}"
     login_docker_registry
   fi

--- a/modules/template_files/templates/startup_script.tpl
+++ b/modules/template_files/templates/startup_script.tpl
@@ -39,7 +39,7 @@ download_docker_image() {
   export OLD_HOME=$HOME
   export HOME=/home/datalab
   if [ -z "$DOCKER_REGISTRY" ]; then
-    echo "Logging into ${DOCKER_REGISTRY}"
+    echo "Logging into $${DOCKER_REGISTRY}"
     login_docker_registry
   fi
   echo "Getting Docker credentials to GCR"
@@ -50,7 +50,7 @@ download_docker_image() {
 }
 
 login_docker_registry() {
-  docker -D login -u ${docker_user} -p ${docker_password} "${DOCKER_REGISTRY}"
+  docker -D login -u ${docker_user} -p ${docker_password} "$${DOCKER_REGISTRY}"
 }
 
 clone_repo() {

--- a/modules/template_files/variables.tf
+++ b/modules/template_files/variables.tf
@@ -104,3 +104,13 @@ variable "append_to_startup_script" {
   description = "Full path to file with content to be added to the startup script."
   type        = string
 }
+
+variable "private_datalab_registry_info" {
+  type = object({
+    secret_project_id   = string
+    user_secret_id      = string
+    password_secret_id  = string
+    docker_registry_url = string
+  })
+  default = null
+}

--- a/modules/template_files/variables.tf
+++ b/modules/template_files/variables.tf
@@ -112,5 +112,4 @@ variable "private_datalab_registry_info" {
     password_secret_id  = string
     docker_registry_url = string
   })
-  default = null
 }

--- a/modules/template_files/versions.tf
+++ b/modules/template_files/versions.tf
@@ -16,4 +16,7 @@
 
 terraform {
   required_version = ">= 0.12"
+  required_providers {
+    google-beta = ">= 3.8"
+  }
 }


### PR DESCRIPTION
allows using secret manager secrets to authenticated to private docker registry which allows to use datalab private image from the registry for extra libraries, native components, etc.
Issue:  the secrets are splatted into the startup script so console users who have permissions to see instances metadata will see the credentials.